### PR TITLE
Use different visitor per event

### DIFF
--- a/lib/tracker.coffee
+++ b/lib/tracker.coffee
@@ -1,8 +1,8 @@
 ua = require('universal-analytics')
 
-visitor = ua('UA-49535937-3')
-
 module.exports = (req, res, next) ->
+  visitor = ua('UA-49535937-3')
+
   eventParams =
     ec: 'API Request'                        # category
     ea: req.get('Referrer') || 'no referrer' # action


### PR DESCRIPTION
Instantiate a 'visitor' on every API request, since GA only tracks 500 events per visitor/session per day.
